### PR TITLE
HMR support

### DIFF
--- a/packages/neutrino-middleware-extractstyles/package.json
+++ b/packages/neutrino-middleware-extractstyles/package.json
@@ -24,6 +24,7 @@
   },
   "main": "src/index.js",
   "dependencies": {
+    "css-hot-loader": "^1.3.2",
     "css-loader": "^0.28.4",
     "extract-text-webpack-plugin": "^2.1.2",
     "style-loader": "^0.18.2"

--- a/packages/neutrino-middleware-extractstyles/src/index.js
+++ b/packages/neutrino-middleware-extractstyles/src/index.js
@@ -18,12 +18,12 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
     loader: styleRule.use('style').get('loader'),
     options: styleRule.use('style').get('options'),
   }
-  
+
   const styleLoaders = Array.from(styleRule.uses.store.keys())
-  .filter((key) => key !== 'style')
-  .map((key) => styleRule.use(key))
-  .map((use) => ({loader: use.get('loader'), options: use.get('options')}))
-  
+    .filter((key) => key !== 'style')
+    .map((key) => styleRule.use(key))
+    .map((use) => ({loader: use.get('loader'), options: use.get('options')}))
+
   const loaderOptions = Object.assign({
     fallback: options.fallback || styleFallback || 'style-loader',
     use: options.use || styleLoaders || 'css-loader',
@@ -32,8 +32,8 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
   const pluginOptions = Object.assign({
     filename: '[name].[hash].css',
   }, options.plugin || {})
-  
-  const loaders = ExtractTextPlugin.extract(loaderOptions])
+
+  const loaders = ExtractTextPlugin.extract(loaderOptions)
 
   styleRule.uses.clear()
 

--- a/packages/neutrino-middleware-extractstyles/src/index.js
+++ b/packages/neutrino-middleware-extractstyles/src/index.js
@@ -19,21 +19,38 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
     options: styleRule.use('style').get('options'),
   }
 
+  options = Object.assign({
+    hot: true,
+    cssHotLoader: {},
+    extract: {},
+    plugin: {},
+    fallback: null,
+    use: null,
+  }, options);
+
   const styleLoaders = Array.from(styleRule.uses.store.keys())
     .filter((key) => key !== 'style')
     .map((key) => styleRule.use(key))
     .map((use) => ({loader: use.get('loader'), options: use.get('options')}))
 
-  const loaderOptions = Object.assign({
+  const extractOptions = Object.assign({
     fallback: options.fallback || styleFallback || 'style-loader',
     use: options.use || styleLoaders || 'css-loader',
-  }, options.loader || {})
+  }, options.extract)
 
   const pluginOptions = Object.assign({
-    filename: '[name].[hash].css',
-  }, options.plugin || {})
+    filename: '[name].css',
+  }, options.plugin)
 
-  const loaders = ExtractTextPlugin.extract(loaderOptions)
+  const loaders = ExtractTextPlugin.extract(extractOptions)
+
+  // css-hot-loader must be first
+  if (options.hot) {
+    loaders.unshift({
+      loader: 'css-hot-loader',
+      options: options.cssHotLoader,
+    })
+  }
 
   styleRule.uses.clear()
 


### PR DESCRIPTION
Adding css-hot-loader support

This also clarifies some options:
- adds `options.cssHotLoader`
- renames `options.loader` to `options.extract`

Note: I branched this off of #2 to avoid conflicts, as it seemed it would be merged soon.
